### PR TITLE
fix: Caption upcase

### DIFF
--- a/lib/meme_captain/caption.rb
+++ b/lib/meme_captain/caption.rb
@@ -45,6 +45,10 @@ module MemeCaptain
       Caption.new(lines.join("\n"))
     end
 
+    def upcase
+      Caption.new(super)
+    end
+
   end
 
 end

--- a/lib/meme_captain/version.rb
+++ b/lib/meme_captain/version.rb
@@ -1,3 +1,3 @@
 module MemeCaptain
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end

--- a/spec/caption_spec.rb
+++ b/spec/caption_spec.rb
@@ -51,4 +51,10 @@ describe MemeCaptain::Caption do
     expect(MemeCaptain::Caption.new('foobar').wrap(2)).to eq('foobar')
   end
 
+  it 'should return Caption instance after upcase' do
+    result = MemeCaptain::Caption.new('foobar').upcase
+    expect(result).to eq('FOOBAR')
+    expect(result.class).to eq(MemeCaptain::Caption)
+  end
+
 end


### PR DESCRIPTION
With changes introduced in https://github.com/ruby/ruby/pull/3701 `String` methods now return `String` instances when called on a subclass instance. Also mentioned here https://rubyreferences.github.io/rubychanges/3.0.html#string-always-returning-string.

This breaks https://github.com/mmb/meme_captain/blob/fb0c6bee922db968e599a24bc8d9221e87edbf34/lib/meme_captain/meme.rb#L36

because `upcase` now returns `String` instead of `Caption`.

This PR defines `Caption#upcase` so it will return a `Caption` instance.